### PR TITLE
fix meetup.com link to kcbrigade

### DIFF
--- a/index.html
+++ b/index.html
@@ -255,7 +255,7 @@ list individual projects here <li><a href="#">Separated link</a></li>
         <h2 class="featurette-heading">We Meet Often. <span class="muted">Hack With Us.</span></h2>
         
   
-        <p class="lead">We have four or five meetups per month. Three are <strong>Hack Nights</strong> where we help build civic apps and open data. One per month is a <strong>Yack Night</strong> where we get to know each other and our local govs. View our <a href="http://www.meetup.com/kcbrigade">
+        <p class="lead">We have four or five meetups per month. Three are <strong>Hack Nights</strong> where we help build civic apps and open data. One per month is a <strong>Yack Night</strong> where we get to know each other and our local govs. View our <a href="http://www.meetup.com/openoakland">
           Meetup.com group</a> for upcoming sessions. We meet every
           Monday where we hack (develop) our projects,
           or brainstorm on current issues and activities around the Oakland area. It's a lot of fun, with great people and (usually) food &amp; drink.</p>


### PR DESCRIPTION
just a stray link that survived the forking, was browsing the site and ended up at the kansas city brigade meetup page.
